### PR TITLE
cheeseburger: proprietary-files-qc: remove init.qcom.post_boot.sh

### DIFF
--- a/proprietary-files-qc.txt
+++ b/proprietary-files-qc.txt
@@ -309,9 +309,6 @@ vendor/lib64/libQtiTether.so
 bin/energy-awareness
 bin/msm_irqbalance
 
-# QCOM post_boot
-etc/init.qcom.post_boot.sh
-
 # Peripheral manager
 bin/pm-proxy
 bin/pm-service


### PR DESCRIPTION
File is not confidential and we already have it checked-in in our device
tree with all the other init configs.

Change-Id: I464943e23b9dde99a75bc1f9adecbe138bcacdcb
Signed-off-by: Alexander Martinz <alex@amartinz.at>